### PR TITLE
Fix continuous listening and use Coqui TTS

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,4 +70,8 @@ if __name__ == "__main__":
     with stream:
         print("🌀 [audio_stream] Hilo de procesamiento iniciado.")
         threading.Thread(target=consumer, daemon=True).start()
-        input("Presiona ENTER para finalizar la llamada...")
+        try:
+            while True:
+                time.sleep(0.1)
+        except KeyboardInterrupt:
+            print("\n👋 Llamada finalizada por el usuario.")

--- a/tts.py
+++ b/tts.py
@@ -1,9 +1,12 @@
-import pyttsx3
+from TTS.api import TTS
+import sounddevice as sd
 
-engine = pyttsx3.init()
-engine.setProperty("rate", 170)
-engine.setProperty("voice", "spanish")  # Puede requerir ajuste según sistema operativo
+# Cargar modelo de español una sola vez
+_tts = TTS("tts_models/es/mai/tacotron2-DDC", progress_bar=False)
 
-def hablar(texto):
-    engine.say(texto)
-    engine.runAndWait()
+
+def hablar(texto: str) -> None:
+    """Reproduce la respuesta generada por la IA usando Coqui TTS."""
+    audio = _tts.tts(texto)
+    sd.play(audio, _tts.synthesizer.output_sample_rate)
+    sd.wait()


### PR DESCRIPTION
## Summary
- keep audio stream active until user presses `Ctrl+C`
- switch TTS engine to Coqui TTS

## Testing
- `python -m py_compile main.py ia.py stt.py tts.py audio_stream.py`
- `python -m pip install --quiet -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_e_684a2880a474832f97af08b2d29f0320