### PR TITLE
Add Makefile target for syntax checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: pycompile
+
+# Compile all Python files to check syntax errors
+pycompile:
+	python -m py_compile *.py


### PR DESCRIPTION
## Summary
- add a `pycompile` target so contributors can quickly check all Python files compile

## Testing
- `make pycompile`


------
https://chatgpt.com/codex/tasks/task_e_684a2bf9cd44832f89709d5b08dcabe0