### PR TITLE
Fix STT JSON parsing

### DIFF
--- a/stt.py
+++ b/stt.py
@@ -1,6 +1,7 @@
 import vosk
 import wave
 import os
+import json
 import numpy as np
 
 # Cargar modelo solo una vez
@@ -26,7 +27,11 @@ def transcribe(audio_data, samplerate):
                 rec.AcceptWaveform(data)
 
         result = rec.Result()
-        text = eval(result).get("text", "")
+        try:
+            text = json.loads(result).get("text", "")
+        except json.JSONDecodeError:
+            print(f"[stt] ⚠️ Error decodificando JSON: {result}")
+            text = ""
         return text.strip()
     finally:
         if os.path.exists(wf_path):


### PR DESCRIPTION
## Summary
- import `json` in `stt.py`
- use `json.loads` instead of `eval` for recognizer results
- warn if JSON decoding fails

## Testing
- `python3 -m py_compile stt.py ia.py tts.py main.py audio_stream.py`


------
https://chatgpt.com/codex/tasks/task_e_684a2beff250832fbe6bea2289d40051