### PR TITLE
Remove unused talking variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 _pycache_
+__pycache__
 models

--- a/main.py
+++ b/main.py
@@ -14,7 +14,6 @@ silence_threshold = 0.01  # umbral de silencio
 max_silence_blocks = 2
 
 # Estados de control
-talking = False
 estado = "ESCUCHANDO"  # Puede ser ESCUCHANDO o PENSANDO
 
 # Buffers y colas


### PR DESCRIPTION
## Summary
- drop the dead `talking` variable from `main.py`
- ignore `__pycache__` files so compiled artifacts are not tracked

## Testing
- `python -m py_compile audio_stream.py ia.py main.py stt.py tts.py`

------
https://chatgpt.com/codex/tasks/task_e_684a2be6ad80832fa9cf77dd11e10c27